### PR TITLE
Fix catalogs for subdirectories

### DIFF
--- a/src/pydap/wsgi/templates/catalog.xml
+++ b/src/pydap/wsgi/templates/catalog.xml
@@ -12,8 +12,8 @@
     <dataset name="{{ file.name }} " ID="{{ location }}{{ file.name }}">
         <dataSize units="bytes">{{ file.size }}</dataSize>
         <date type="modified">{{ file.last_modified|datetimeformat_iso }}</date>
-        <access serviceName="odap" urlPath="{{ location }}{{ file.name }}"/>
-        <access serviceName="file" urlPath="{{ location }}{{ file.name }}"/>
+        <access serviceName="odap" urlPath="{{ file.name }}"/>
+        <access serviceName="file" urlPath="{{ file.name }}"/>
     </dataset>
     {% endif %}
     {% endfor %}


### PR DESCRIPTION
These links seem to be interpreted as relative paths, so the directory is already implied.
This patch fixes problems I was having when browsing a sub-catalog in Panoply and IDV.  Hopefully I'm not breaking other use cases.